### PR TITLE
Add internal API

### DIFF
--- a/src/api/reflect/Acl.php
+++ b/src/api/reflect/Acl.php
@@ -5,12 +5,6 @@
 
     class _ReflectAcl extends API {
         public static $rules = [
-            "id"       => [
-                "required" => false,
-                "type"     => "text",
-                "min"      => 1,
-                "max"      => 32
-            ],
             "api_key"  => [
                 "required" => true,
                 "max"      => 32
@@ -63,15 +57,14 @@
                 return $this->stderr("Invalid HTTP method", 400, "'{$_POST["method"]}' is not a valid HTTP verb");
             }
 
-            // Derive key from a SHA256 hash of user id and current time
-            // if no custom key is provided
-            if (empty($_POST["id"])) {
-                $_POST["id"] = uniqid("", true);
-            }
-
             $sql = "INSERT INTO api_acl (id, api_key, endpoint, method, created) VALUES (?, ?, ?, ?, ?)";
             $res = $this->db->return_bool($sql, [
-                $_POST["id"],
+                // Id will be a SHA256 hash of all ACL fields truncated to 32 chars
+                substr(hash("sha256", implode("", [
+                    $_POST["api_key"],
+                    $_POST["endpoint"],
+                    $_POST["method"]
+                ])), -32),
                 $_POST["api_key"],
                 $_POST["endpoint"],
                 $_POST["method"],

--- a/src/api/reflect/Acl.php
+++ b/src/api/reflect/Acl.php
@@ -1,0 +1,83 @@
+<?php
+
+    require_once Path::api();
+    require_once Path::src("database/Auth.php");
+
+    class _ReflectAcl extends API {
+        public static $rules = [
+            "id"       => [
+                "required" => false,
+                "type"     => "text",
+                "min"      => 1,
+                "max"      => 32
+            ],
+            "api_key"  => [
+                "required" => true,
+                "max"      => 32
+            ],
+            "endpoint" => [
+                "required" => true,
+                "max"      => 32
+            ],
+            "method"   => [
+                "required" => true,
+                "type"     => "text"
+            ]
+        ];
+
+        public function __construct() {
+            parent::__construct(ContentType::JSON);
+            $this->db = new AuthDB(ConType::INTERNAL);
+        }
+
+        // Get order status by order reference
+        public function _GET() {
+            // Return ACL details by id
+            if (!empty($_GET["id"])) {
+                $sql = "SELECT id, api_key, endpoint, method, created FROM api_acl WHERE id = ?";
+                $res = $this->db->return_array($sql, $_GET["id"]);
+
+                return !empty($res) ? $this->stdout($res) : $this->stderr("No record", 404, "No ACL record found with id '{$_GET["id"]}'");
+            }
+
+            // Return array of all active Reflect API users
+            $sql = "SELECT id, created FROM api_acl";
+            return $this->stdout($this->db->return_array($sql));
+        }
+
+        public function _POST() {
+            // Check key is valid
+            $key = $this->call("reflect/Key?id={$_POST["api_key"]}");
+            if (empty($key)) {
+                return $this->stderr("Unprocessable entity", 422, $key);
+            }
+
+            // Check user is valid
+            $user = $this->call("reflect/User?id={$_POST["api_key"]}");
+            if (empty($user)) {
+                return $this->stderr("Unprocessable entity", 422, $user);
+            }
+
+            // Check method is in whitelist
+            if (!Method::tryFrom($_POST["method"])) {
+                return $this->stderr("Invalid HTTP method", 400, "'{$_POST["method"]}' is not a valid HTTP verb");
+            }
+
+            // Derive key from a SHA256 hash of user id and current time
+            // if no custom key is provided
+            if (empty($_POST["id"])) {
+                $_POST["id"] = uniqid("", true);
+            }
+
+            $sql = "INSERT INTO api_acl (id, api_key, endpoint, method, created) VALUES (?, ?, ?, ?, ?)";
+            $res = $this->db->return_bool($sql, [
+                $_POST["id"],
+                $_POST["api_key"],
+                $_POST["endpoint"],
+                $_POST["method"],
+                time()
+            ]);
+
+            return !empty($res) ? $this->stdout("OK") : $this->stderr("Failed to add ACL rule", 500, $res);
+        }
+    }

--- a/src/api/reflect/Endpoint.php
+++ b/src/api/reflect/Endpoint.php
@@ -1,0 +1,111 @@
+<?php
+
+    require_once Path::api();
+    require_once Path::src("database/Auth.php");
+
+    class _ReflectEndpoint extends API {
+        public static $rules = [
+            "endpoint" => [
+                "required" => true,
+                "type"     => "text",
+                "max"      => 128
+            ]
+        ];
+
+        public function __construct() {
+            parent::__construct(ContentType::JSON);
+            $this->db = new AuthDB(ConType::INTERNAL);
+        }
+
+        private static function uc_first_endpoint(string $endpoint): string|bool {
+            // Split endpoint string into crumbs
+            $crumbs = explode("/", $endpoint);
+            // Endpoint must contain at least one slash
+            if (count($crumbs) < 2) {
+                return false;
+            }
+
+            // Capitalize first char of endpoint
+            $key = array_key_last($crumbs);
+            $crumbs[$key] = ucfirst($crumbs[$key]);
+
+            // Reconstruct string
+            return implode("/", $crumbs);
+        }
+
+        // Get endpoints
+        public function _GET() {
+            // Check if endpoint exists by name
+            if (!empty($_GET["id"])) {
+                $sql = "SELECT NULL FROM api_endpoints WHERE endpoint = ? AND active = 1";
+                $res = $this->db->return_bool($sql, $_GET["id"]);
+
+                return !empty($res) ? $this->stdout("OK") : $this->stderr("No endpoint", 404, "No endpoint found with name '{$_GET["id"]}'");
+            }
+
+            // Return array of all active Reflect API users
+            $sql = "SELECT endpoint FROM api_endpoints WHERE active = 1";
+            return $this->stdout($this->db->return_array($sql));
+        }
+
+        public function _PATCH() {
+            // Array of columns to patch
+            $update = [];
+
+            if (!empty($_POST["endpoint"])) {
+                $_POST["endpoint"] = $this::uc_first_endpoint($_POST["endpoint"]);
+                if (empty($_POST["endpoint"])) {
+                    return $this->stderr("Invalid endpoint", 400, "Endpoint name must contain scope and endpoint separated by a slash");
+                }
+
+                $update["endpoint"] = $_POST["endpoint"];
+            }
+
+            // Build SQL UPDATE CSV from array of values
+            $columns = array_map(fn($column): string => "${column} = ?", array_keys($update));
+            $columns = implode(",", $columns);
+
+            $sql = "UPDATE api_endpoints SET ${columns} WHERE id = ?";
+            // Create new array with id of target row appended to array of column values
+            $res = $this->db->return_bool($sql, array_merge(
+                array_values($update),
+                [$_GET["id"]]
+            ));
+
+            return !empty($res) ? $this->stdout("OK") : $this->stderr("Failed to update", 400, $res);
+        }
+
+        // Add new endpoint
+        public function _POST() {
+            $endpoint = $this::uc_first_endpoint($_POST["endpoint"]);
+            if (empty($endpoint)) {
+                return $this->stderr("Invalid endpoint", 400, "Endpoint name must contain scope and endpoint separated by a slash");
+            }
+
+            // Capitalize first char of endpoint
+            $key = array_key_last($crumbs);
+            $crumbs[$key] = ucfirst($crumbs[$key]);
+
+            // Attempt to add endpoint
+            $sql = "INSERT INTO api_endpoints (endpoint, active) VALUES (?, ?)";
+            $res = $this->return_bool($sql, [
+                $_POST["endpoint"],
+                1
+            ]);
+
+            return !empty($res) ? $this->stdout("OK") : $this->stderr("Failed to add endpoint", 500, $res);
+        }
+
+        // Delete endpoint by name
+        public function _DELETE() {
+            // Check that we got an id from the requester
+            if (empty($_GET["id"])) {
+                return $this->stderr("No id provided", 400, "Parameter id can not be empty");
+            }
+
+            // Soft-delete by deactivating endpoint by name
+            $sql = "UPDATE api_endpoints SET active = 0 WHERE endpoint = ?";
+            $res = $this->db->return_bool($sql, $_GET["id"]);
+            return !empty($res) ? $this->stdout("OK") : $this->stderr("Failed to delete endpoint", 500, $res);
+        }
+    }

--- a/src/api/reflect/Key.php
+++ b/src/api/reflect/Key.php
@@ -40,13 +40,13 @@
                 $res = $this->db->return_array($sql, $_GET["id"]);
 
                 if (empty($res)) {
-                    return $this->stdout("Failed to get key data", 422, $res);
+                    return $this->stderr("Failed to get key data", 422, $res);
                 }
 
                 // Flatten array
                 $res = $res[0];
                 // Resolve user foregin key
-                $res["user"] = $this->call("reflect/User?id={$res["user"]}");
+                $res["user"] = $this->call("reflect/User?id={$res["user"]}")[0]["id"];
 
                 return $this->stdout($res);
             }
@@ -60,8 +60,16 @@
             // Array of columns to patch
             $update = [];
 
-            if (!empty($_POST["id"])) {
-                $update["id"] = $_POST["id"];
+            if (empty($_GET["id"])) {
+                return $this->stderr("No key selected", 404, "Param 'id' is required");
+            }
+
+            if (!empty($_POST["active"])) {
+                if (!is_bool($_POST["active"])) {
+                    return $this->stderr("Invalid data type", 400, "Expected field 'active' to be of type boolean");
+                }
+
+                $update["active"] = $_POST["active"];
             }
 
             if (!empty($_POST["user"])) {

--- a/src/api/reflect/Key.php
+++ b/src/api/reflect/Key.php
@@ -1,0 +1,151 @@
+<?php
+
+    require_once Path::api();
+    require_once Path::src("database/Auth.php");
+
+    class _ReflectKey extends API {
+        public static $rules = [
+            "id"      => [
+                "required" => false,
+                "type"     => "text",
+                "min"      => 32,
+                "max"      => 32
+            ],
+            "user"    => [
+                "required" => true
+            ],
+            "expires" => [
+                "required" => false,
+                "type"     => "int"
+            ]
+        ];
+        
+        public function __construct() {
+            parent::__construct(ContentType::JSON);
+            $this->db = new AuthDB(ConType::INTERNAL);
+        }
+
+        // Check that timestamp is not in the past from now
+        private static function time_valid(int $key): bool {
+            return $key > time();
+        }
+
+        // Get order status by order reference
+        public function _GET() {
+            $sql_time_clamp = "CURRENT_TIMESTAMP() BETWEEN `created` AND COALESCE(`expires`, NOW())";
+
+            // Return bool if Reflect API user exists and is active by id
+            if (!empty($_GET["id"])) {
+                $sql = "SELECT id, active, user, expires, created FROM api_keys WHERE id = ?";
+                $res = $this->db->return_array($sql, $_GET["id"]);
+
+                if (empty($res)) {
+                    return $this->stdout("Failed to get key data", 422, $res);
+                }
+
+                // Flatten array
+                $res = $res[0];
+                // Resolve user foregin key
+                $res["user"] = $this->call("reflect/User?id={$res["user"]}");
+
+                return $this->stdout($res);
+            }
+
+            // Return array of all active Reflect API users
+            $sql = "SELECT id, created, expires FROM api_keys WHERE active = 1 AND ${sql_time_clamp}";
+            return $this->stdout($this->db->return_array($sql));
+        }
+
+        public function _PATCH() {
+            // Array of columns to patch
+            $update = [];
+
+            if (!empty($_POST["id"])) {
+                $update["id"] = $_POST["id"];
+            }
+
+            if (!empty($_POST["user"])) {
+                // Check that user exists and is active
+                if (!$this->user_valid($_POST["user"])) {
+                    return $this->stderr("No user", 404, "No Reflect user found with id '{$_POST["user"]}'");
+                }
+
+                $update["user"] = $_POST["user"];
+            }
+
+            // Check expiry date is greater than current timestamp
+            if (!empty($_POST["expires"])) {
+                if (!$this::time_valid($_POST["expires"])) {
+                    return $this->stderr("Invalid expiry timestamp", 400, "Expiry UNIX timestamp must be greater than current time");
+                }
+
+                $update["expires"] = $_POST["expires"];
+            }
+
+            // Build SQL UPDATE CSV from array of values
+            $columns = array_map(fn($column): string => "${column} = ?", array_keys($update));
+            $columns = implode(",", $columns);
+
+            $sql = "UPDATE api_keys SET ${columns} WHERE id = ?";
+            // Create new array with id of target row appended to array of column values
+            $res = $this->db->return_bool($sql, array_merge(
+                array_values($update),
+                [$_GET["id"]]
+            ));
+
+            return !empty($res) ? $this->stdout("OK") : $this->stderr("Failed to update", 400, $res);
+        }
+
+        // Create new API key for user
+        public function _POST() {
+            // Reflect user must exist before creating a key
+            if ($this->call("reflect/user?id={$_POST["user"]}", Method::GET) !== "OK") {
+                return $this->stderr("No user", 404, "No Reflect user found with id '{$_POST["user"]}'");
+            }
+
+            // Check expiry date is greater than current timestamp
+            if (!empty($_POST["id"]) && !$this::key_valid($_POST["id"])) {
+                return $this->stderr("Invalid expiry date", 400, "Expiry date must be greater than current time");
+            }
+
+            // Derive key from a SHA256 hash of user id and current time
+            // if no custom key is provided
+            if (empty($_POST["id"])) {
+                $_POST["id"] = substr(hash("sha256", implode("", [$_POST["user"], time()])), -32);
+            }
+
+            // Attempt to insert key
+            $sql = "INSERT INTO api_keys (id, active, user, expires, created) VALUES (?, ?, ?, ?, ?)";
+            $res = $this->db->return_bool($sql, [
+                $_POST["id"],
+                // Set active
+                1,
+                // Set user id
+                $_POST["user"],
+                // Set expiry timestamp if defined
+                !empty($_POST["expires"]) ? $_POST["expires"] : null,
+                // Set created timestamp
+                time()
+            ]);
+
+            return !empty($res) ? $this->stdout("OK") : $this->stderr("Failed to create key", 500, $res);
+        }
+
+        // Delete key by id
+        public function _DELETE() {
+            // Check that we got an id from the requester
+            if (empty($_GET["id"])) {
+                return $this->stderr("No id provided", 400, "Parameter id can not be empty");
+            }
+
+            // Check that the key exists and is active
+            if (empty($this->call("reflect/Key?id={$_GET["id"]}", Method::GET))) {
+                return $this->stderr("No key", 404, "Key is inactive or does not exist");
+            }
+
+            // Soft-delete by deactivating key by id
+            $sql = "UPDATE api_keys SET active = 0 WHERE id = ?";
+            $res = $this->return_bool($sql, $_GET["id"]);
+            return !empty($res) ? $this->stdout("OK") : $this->stderr("Failed to delete key", 500, $res);
+        }
+    }

--- a/src/api/reflect/User.php
+++ b/src/api/reflect/User.php
@@ -1,0 +1,46 @@
+<?php
+
+    require_once Path::api();
+    require_once Path::src("database/Auth.php");
+
+    class _ReflectUser extends API {
+        public static $rules = [
+            "id" => [
+                "required" => true,
+                "type"     => "text"
+            ],
+            "active" => [
+                "required" => false,
+                "type"     => "bool"
+            ]
+        ];
+
+        public function __construct() {
+            parent::__construct(ContentType::JSON);
+            $this->db = new AuthDB(ConType::INTERNAL);
+        }
+
+        // Get order status by order reference
+        public function _GET() {
+            // Return bool if Reflect API user exists and is active by id
+            if (!empty($_GET["id"])) {
+                return $this->db->user_active($_GET["id"]) 
+                    ? $this->stdout("OK") 
+                    : $this->stderr("No user", 404, "User is inactive or does not exist");
+            }
+
+            // Return array of all active Reflect API users
+            $sql = "SELECT id, created FROM api_users WHERE active = 1";
+            return $this->stdout($this->db->return_array($sql));
+        }
+
+        // Create new Reflect API user
+        public function _POST() {
+            $sql = "INSERT INTO api_users (id, active, created) VALUES (?, ?, ?)";
+            return $this->stdout($sql, [
+                $_POST["id"],
+                !empty($_POST["active"]) ? $_POST["active"] : 1,
+                time()
+            ]);
+        }
+    }

--- a/src/api/reflect/User.php
+++ b/src/api/reflect/User.php
@@ -20,7 +20,7 @@
             $this->db = new AuthDB(ConType::INTERNAL);
         }
 
-        // Get order status by order reference
+        // Get details of all active users
         public function _GET() {
             // Return bool if Reflect API user exists and is active by id
             if (!empty($_GET["id"])) {
@@ -29,12 +29,22 @@
                     : $this->stderr("No user", 404, "User is inactive or does not exist");
             }
 
-            // Return array of all active Reflect API users
+            // Return array of all active users
             $sql = "SELECT id, created FROM api_users WHERE active = 1";
             return $this->stdout($this->db->return_array($sql));
         }
 
-        // Create new Reflect API user
+        // Set active state of user
+        public function _PUT() {
+            $sql = "UPDATE api_users SET active = ? WHERE id = ?";
+            return $this->stdout($sql,
+                // Default state to active if undefined
+                empty($_POST["active"]) ?: true,
+                $_GET["id"]
+            );
+        }
+
+        // Create new user
         public function _POST() {
             $sql = "INSERT INTO api_users (id, active, created) VALUES (?, ?, ?)";
             return $this->stdout($sql, [
@@ -42,5 +52,24 @@
                 !empty($_POST["active"]) ? $_POST["active"] : 1,
                 time()
             ]);
+        }
+
+        // Delete user by id
+        public function _DELETE() {
+            // Check that we got an id from the requester
+            if (empty($_GET["id"])) {
+                return $this->stderr("No id provided", 400, "Parameter id can not be empty");
+            }
+
+            // Check that the user exists and is active
+            $user = $this->call("reflect/User?id={$_GET["id"]}", Method::GET);
+            if ($user !== "OK") {
+                return $this->stderr("No user", 404, "User is inactive or does not exist");
+            }
+
+            // Soft-delete by deactivating user by id
+            $sql = "UPDATE api_users SET active = 0 WHERE id = ?";
+            $res = $this->return_bool($sql, $_GET["id"]);
+            return !empty($res) ? $this->stdout("OK") : $this->stderr("Failed to delete user", 500, $res);
         }
     }

--- a/src/api/reflect/session/Key.php
+++ b/src/api/reflect/session/Key.php
@@ -1,0 +1,16 @@
+<?php
+
+    require_once Path::api();
+    require_once Path::src("database/Auth.php");
+
+    class _ReflectSessionKey extends API {
+        public function __construct() {
+            parent::__construct(ContentType::JSON);
+            $this->db = new AuthDB(ConType::INTERNAL);
+        }
+
+        // Get order status by order reference
+        public function _GET() {
+            return $this->stdout($this->db->get_api_key());
+        }
+    }

--- a/src/api/reflect/session/User.php
+++ b/src/api/reflect/session/User.php
@@ -1,0 +1,59 @@
+<?php
+
+    require_once Path::api();
+    require_once Path::src("database/Auth.php");
+
+    class _ReflectSessionUser extends API {
+        public static $rules = [
+            "active" => [
+                "required" => true,
+                "type"     => "bool"
+            ]
+        ];
+
+        public function __construct() {
+            parent::__construct(ContentType::JSON);
+            $this->db = new AuthDB(ConType::INTERNAL);
+        }
+
+        // Get order status by order reference
+        public function _GET() {
+            // Resolve user id from current key
+            $sql = "SELECT user FROM api_keys WHERE id = ?";
+            $res = $this->db->return_array($sql, $this->db->get_api_key());
+
+            // Current key is not in keys table.
+            // This is probably a configuration error. The requester key had access in the ACL table
+            // to make the call, but the corresponding key does not exist. Restore from backup and make
+            // sure that foregin key constraints are enabled.
+            if (empty($res)) {
+                $this->stderr("Key error", 500, "Requester API key can not be found. This is a big problem");
+            }
+
+            // Flatten array
+            $res = $res[0];
+
+            // User is not active
+            return $this->call("reflect/User?id={$res["user"]}")
+                ? $this->stdout($res["user"])
+                : $this->stderr("No user", 404, "API user is disabled or does not exist");
+        }
+
+        // Delete own user (by flagging it as inactive)
+        public function _DELETE() {
+            // Get user id from key
+            $user_id = $this->call("reflect/session/User", Method::GET);
+            // Trying to delete a Reflect default user will probably cause problems.
+            // A default user can not be deleted from the session endpoints.
+            if (empty($user_id) || $user_id === "HTTP_ANYONE") {
+                return $this->stderr("Failed get user id", 422, $user_id);
+            }
+
+            // Attempt to delete own user
+            $sql = "UPDATE api_users SET active = ? WHERE id = ?";
+            $res = $this->db->return_bool($sql, [0, $user_id]);
+            return !empty($res) 
+                ? $this->stdout("OK") 
+                : $this->stderr("Failed to delete user", 422, $res);
+        }
+    }

--- a/src/request/Router.php
+++ b/src/request/Router.php
@@ -115,7 +115,12 @@
             $endpoint = $this->get_endpoint_path($_SERVER["REQUEST_URI"]);
 
             // Check that the endpoint exists.
-            $path = Path::endpoints("public/${endpoint}.php");
+            // If root endpoint starts with "reflect/" read from the internal_endpoint folder
+            // as this is a meta-request for details about the current Reflect instance.
+            $path = substr($endpoint, 0, 8) !== "reflect/" 
+                ? Path::endpoints("public/${endpoint}.php") 
+                : Path::src("api/${endpoint}.php");
+
             if (!file_exists($path)) {
                 return $this->exit_here_with_error("No endpoint", 404, "The requested endpoint does not exist");
             }


### PR DESCRIPTION
This PR adds internal endpoints that allow Reflect itself to be managed via Reflect endpoints.

Using `API->call()` as you would with any other internal request. Reflect features like adding keys, ACL etc. can be called in the same RESTful way by using the "reflect/" namespace in an internal request.

```php
// Will return the `api_users` row id the key used with the
// current request originated from.
API->call("reflect/session/User", Method::GET);

// Create new ACL entry to grant/revoke access to an API key
API->call("reflect/Acl", Method::POST, [
  $id,
  $key,
  $endpoint
]);
```

And more.. [read more on the wiki page](#todo)