### PR TITLE
Fix assertion bug when rule `required` is false on falsy values

### DIFF
--- a/src/api/helpers/RuleMatcher.php
+++ b/src/api/helpers/RuleMatcher.php
@@ -54,7 +54,7 @@
 
         // Return true if field is required and not null
         public static function rule_required(mixed $value, bool $cstr = true): string|bool {
-            $match = $cstr && !empty($value) ? true : !empty($value);
+            $match = $cstr && !empty($value) ? true : isset($value);
             return $match ?: "This field can not be empty";
         }
     }


### PR DESCRIPTION
If a POST rule is set to `"required" => false` and the value expected is something `empty()` would consider falsy, it will not match.