### PR TITLE
Fix null passed to json_decode bug when socket server receives empty req body

### DIFF
--- a/src/cli/socket/SocketServer.php
+++ b/src/cli/socket/SocketServer.php
@@ -31,7 +31,11 @@
             }
 
             $uri = parse_url($uri);
-            $_POST = json_decode($data, true) ?? null;
+
+            // Load request body fields into $_POST superglobal if set
+            if (!empty($data)) {
+                $_POST = json_decode($data, true);
+            }
 
             $_SERVER['REQUEST_URI'] = isset($uri["path"]) ? "/" . $uri["path"] : "/"; // Set request path with leading slash
             isset($uri["query"]) ? parse_str($uri["query"], $_GET) : null; // Set request parameters


### PR DESCRIPTION
Sending an empty request body to a Request endpoint over a UNIX socket connection will cause the socket server to crash due to it trying to read the empty body as JSON into $_POST.

This PR makes it so it will only try to populate $_POST if a payload is received.