### PR TITLE
Fix idempotency for INTERNAL connections

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -4,4 +4,4 @@
 
 	// Do request routing
 	require_once Path::reflect("src/request/Router.php");
-	(new Router(ConType::HTTP))->main();
+	(new Router(Connection::HTTP))->main();

--- a/src/api/reflect/acl.php
+++ b/src/api/reflect/acl.php
@@ -21,7 +21,7 @@
 
         public function __construct() {
             parent::__construct(ContentType::JSON);
-            $this->db = new AuthDB(ConType::INTERNAL);
+            $this->db = new AuthDB(Connection::INTERNAL);
         }
 
         // Get order status by order reference

--- a/src/api/reflect/endpoint.php
+++ b/src/api/reflect/endpoint.php
@@ -18,7 +18,7 @@
 
         public function __construct() {
             parent::__construct(ContentType::JSON);
-            $this->db = new AuthDB(ConType::INTERNAL);
+            $this->db = new AuthDB(Connection::INTERNAL);
         }
 
         private static function uc_first_endpoint(string $endpoint): string|bool {

--- a/src/api/reflect/key.php
+++ b/src/api/reflect/key.php
@@ -26,7 +26,7 @@
         
         public function __construct() {
             parent::__construct(ContentType::JSON);
-            $this->db = new AuthDB(ConType::INTERNAL);
+            $this->db = new AuthDB(Connection::INTERNAL);
         }
 
         // Check that timestamp is not in the past from now

--- a/src/api/reflect/session/key.php
+++ b/src/api/reflect/session/key.php
@@ -6,7 +6,7 @@
     class _ReflectSessionKey extends API {
         public function __construct() {
             parent::__construct(ContentType::JSON);
-            $this->db = new AuthDB(ConType::INTERNAL);
+            $this->db = new AuthDB(Connection::INTERNAL);
         }
 
         // Get order status by order reference

--- a/src/api/reflect/session/user.php
+++ b/src/api/reflect/session/user.php
@@ -13,7 +13,7 @@
 
         public function __construct() {
             parent::__construct(ContentType::JSON);
-            $this->db = new AuthDB(ConType::INTERNAL);
+            $this->db = new AuthDB(Connection::INTERNAL);
         }
 
         // Get order status by order reference

--- a/src/api/reflect/user.php
+++ b/src/api/reflect/user.php
@@ -17,7 +17,7 @@
 
         public function __construct() {
             parent::__construct(ContentType::JSON);
-            $this->db = new AuthDB(ConType::INTERNAL);
+            $this->db = new AuthDB(Connection::INTERNAL);
         }
 
         // Get details of all active users

--- a/src/cli/socket/SocketServer.php
+++ b/src/cli/socket/SocketServer.php
@@ -41,7 +41,7 @@
             isset($uri["query"]) ? parse_str($uri["query"], $_GET) : null; // Set request parameters
             
             // Initialize request router
-            (new Router(ConType::AF_UNIX))->main();
+            (new Router(Connection::AF_UNIX))->main();
         }
 
         // Stop server

--- a/src/database/Auth.php
+++ b/src/database/Auth.php
@@ -11,7 +11,7 @@
         // I.e request using API->call() or Reflect's meta-endpoints.
         public static $key_internal = "INTERNAL";
 
-        public function __construct(private ConType $con) {
+        public function __construct(private Connection $con) {
             parent::__construct(...$_ENV["mariadb"]);
         }
 
@@ -70,7 +70,7 @@
             }
 
             // Internal connections are always allowed
-            if (in_array($this->con, [ConType::INTERNAL, ConType::AF_UNIX])) {
+            if (in_array($this->con, [Connection::INTERNAL, Connection::AF_UNIX])) {
                 return true;
             }
 


### PR DESCRIPTION
Renamed the `ConType` enum in Router.php to `Connection` to remove ambiguation with the `ContentType` enum in API.php.

With this new name, I also made `Connection::INTERNAL` skip idempotency checks, since the upstream connection will already have had idempotency checks performed.