### PR TITLE
Coercive boolean from string

### DIFF
--- a/src/api/builtin/Rules.php
+++ b/src/api/builtin/Rules.php
@@ -36,7 +36,17 @@
 
                 case "boolean":
                 case "bool":
-                    return is_bool($value) ?: "Must be of type boolean";
+                    if (is_bool($value)) {
+                        return $value;
+                    }
+
+                    // Coercive boolean from string
+                    return in_array($value, [
+                        "true",
+                        "yes",
+                        "false",
+                        "no"
+                    ]) ?: "Must be of type boolean";
 
                 case "object":
                 case "array":


### PR DESCRIPTION
Accept truthy strings as booleans when used in `$_GET` parameters etc.

This will hopefully be a temporary fix until the `Rules` builtin is refactored.