### PR TITLE
Treat null key in ACL as public endpoint

### DIFF
--- a/.env.example.ini
+++ b/.env.example.ini
@@ -36,10 +36,3 @@ socket_mode = 01750
 # 
 # Absolute path to the *directory* where an SQLite database for idempotency keys will be created.
 ;idempotency = "/var/lib/reflect/"
-
-## Custom HTTP public/anonymous API key
-# Set a custom API key to use for public/anonymous requests
-# - Defaults to: 'PUBLIC_API_KEY'
-# - Read more at: https://github.com/victorwesterlund/reflect/wiki/public-endpoints
-# 
-;public_api_key = "PUBLIC_API_KEY"

--- a/composer.lock
+++ b/composer.lock
@@ -48,16 +48,16 @@
         },
         {
             "name": "victorwesterlund/libmysqldriver",
-            "version": "3.1.3",
+            "version": "3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/VictorWesterlund/php-libmysqldriver.git",
-                "reference": "d9f450112ed393c122c92bac8462641f32406af1"
+                "reference": "3f97e7b1f067aa21eed492b22a3e7219e9c603a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/VictorWesterlund/php-libmysqldriver/zipball/d9f450112ed393c122c92bac8462641f32406af1",
-                "reference": "d9f450112ed393c122c92bac8462641f32406af1",
+                "url": "https://api.github.com/repos/VictorWesterlund/php-libmysqldriver/zipball/3f97e7b1f067aa21eed492b22a3e7219e9c603a8",
+                "reference": "3f97e7b1f067aa21eed492b22a3e7219e9c603a8",
                 "shasum": ""
             },
             "type": "library",
@@ -79,9 +79,9 @@
             "description": "Abstraction library for common mysqli features",
             "support": {
                 "issues": "https://github.com/VictorWesterlund/php-libmysqldriver/issues",
-                "source": "https://github.com/VictorWesterlund/php-libmysqldriver/tree/3.1.3"
+                "source": "https://github.com/VictorWesterlund/php-libmysqldriver/tree/3.1.7"
             },
-            "time": "2023-11-03T12:40:54+00:00"
+            "time": "2023-12-31T16:33:59+00:00"
         },
         {
             "name": "victorwesterlund/libsqlitedriver",

--- a/src/database/init/AUTH.sql
+++ b/src/database/init/AUTH.sql
@@ -20,7 +20,7 @@ SET time_zone = "+00:00";
 
 CREATE TABLE `api_acl` (
   `id` varchar(32) NOT NULL,
-  `api_key` varchar(255) NOT NULL COMMENT 'foreign_key:api_keys.id',
+  `api_key` varchar(255) COMMENT 'foreign_key:api_keys.id',
   `endpoint` varchar(255) NOT NULL COMMENT 'foreign_key:api_endpoints.id',
   `method` enum('GET','POST','PUT','PATCH','DELETE') NOT NULL,
   `created` int(32) NOT NULL


### PR DESCRIPTION
This PR removes the "default API key" environment variable and database user. Any ACL rule with its `key` column set to `NULL` will be treated as a public API.

This PR also closes #48 