### PR TITLE
Add `Request` builtin for request metadata

### DIFF
--- a/src/api/builtin/Request.php
+++ b/src/api/builtin/Request.php
@@ -1,0 +1,14 @@
+<?php
+
+	namespace Reflect;
+
+	use Reflect\Path;
+	use Reflect\Database\Database;
+
+	require_once Path::reflect("src/database/Database.php");
+
+	class Request extends Database {
+		public static function get_api_key(): ?string {
+			return parent::get_key_from_request();
+		}
+	}

--- a/src/request/Router.php
+++ b/src/request/Router.php
@@ -14,6 +14,7 @@
     
     // These builtins should be exposed to endpoints in userspace
     require_once Path::reflect("src/api/builtin/Response.php");
+    require_once Path::reflect("src/api/builtin/Request.php");
     require_once Path::reflect("src/api/builtin/Endpoint.php");
     require_once Path::reflect("src/api/builtin/Method.php");
     require_once Path::reflect("src/api/builtin/Call.php");


### PR DESCRIPTION
This PR adds a new Reflect builtin class `Request`.

`Request` should contain information about the request itself that Reflect has processed. It only contains `Request::get_api_key()` for now but more can be added in the future, for example resolving user, group or even which ACL rule was matched.