### PR TITLE
Return HTTP 400 if request body contains invalid JSON

### DIFF
--- a/src/request/Router.php
+++ b/src/request/Router.php
@@ -48,8 +48,8 @@
         // Polyfill for loading parameters from a JSON request body into $_POST
         private static function load_json_payload() {
             $decode = json_decode(file_get_contents("php://input"), true);
-            if (!empty($decode) && !is_array($decode)) {
-                return new Response("Failed to decode JSON request body", 422);
+            if ($decode === null) {
+                return new Response("Request body contains invalid JSON", 400);
             }
 
             return $_POST = $decode ?? [];


### PR DESCRIPTION
Return a HTTP 400 response if a request body does not contain valid JSON when the `application/json` request header has been set.