### PR TITLE
Refactored Reflect\Call function into a class

### DIFF
--- a/src/Init.php
+++ b/src/Init.php
@@ -28,7 +28,8 @@
 
 		// END User configurable environment variables
 
-		case INTERNAL_STDOUT = "internal_stdout";
+		case INTERNAL_STDOUT      = "internal_stdout";
+		case INTERNAL_STDOUT_RESP = "internal_stdout_resp";
 
 		// Returns true if Reflect environment variable is present and not empty in 
 		public static function isset(ENV $key): bool {

--- a/src/api/builtin/Response.php
+++ b/src/api/builtin/Response.php
@@ -27,11 +27,11 @@
             // Set Content-Type of response with MIME type from enum
             header("Content-Type: {$this->type}");
 
-            // Response is not an internal request (from Call()) so we need to trigger an output from here
+            // Response is not an internal request (from Call Reflect\Call) so we need to trigger an output from here
             ENV::isset(ENV::INTERNAL_STDOUT) ? $this->stdout_internal() : $this->stdout_http();
         }
 
-        // Return output data directly. This method can be accessed from Reflect Call()
+        // Return output data directly. This method can be accessed from Reflect\Call
         public function output(): mixed {
             return $this->output;
         }
@@ -44,8 +44,11 @@
             exit($this->type === self::DEFAULT_TYPE ? json_encode($this->output) : $this->output);
         }
 
-        // Write data to Reflect Call() standard output
+        // Return Response to an internal request. Most likely from Reflect\Call
         private function stdout_internal(): mixed {
-            return $this->output();
+            // Set response envvar which lets downstream methods know we have a Response ready
+            ENV::set(ENV::INTERNAL_STDOUT_RESP, [$this->output, $this->code]);
+
+            return $this->output;
         }
     }

--- a/src/api/helpers/GlobalSnapshot.php
+++ b/src/api/helpers/GlobalSnapshot.php
@@ -20,11 +20,7 @@
         private array $argv;
         private ?array $__composer_autoload_files;
 
-        public function __construct() {
-            foreach (array_keys($GLOBALS) as $global) {
-                $this->{$global} = $GLOBALS[$global];
-            }
-        }
+        public function __construct() {}
 
         // Clear a superglobal array
         private function truncate(string $global) {
@@ -39,6 +35,12 @@
 
                 $this->truncate($global);
                 $$global = $this->{$global};
+            }
+        }
+
+        public function capture() {
+            foreach (array_keys($GLOBALS) as $global) {
+                $this->{$global} = $GLOBALS[$global];
             }
         }
     }

--- a/src/request/Router.php
+++ b/src/request/Router.php
@@ -138,6 +138,11 @@
             // Create instance of endpoint class
             $endpoint = new $class();
 
+			// Bail out if a Response has been set before leaving the endpoint constructor scope
+			if (ENV::isset(ENV::INTERNAL_STDOUT_RESP)) {
+				return new Response(...ENV::get(ENV::INTERNAL_STDOUT_RESP));
+			}
+
             // Run main() method from endpoint class or return No Content respone if the endpoint didn't return
             return $endpoint->main() ?? new Response("", 204);
         }


### PR DESCRIPTION
This PR implements the `Reflect\Call` convention used in [reflect-client-php@3.0.0](https://github.com/VictorWesterlund/reflect-client-php/releases/tag/3.0.0).

`Reflect\Call` is now a class which uses chainable methods to define parameters and request methods. [See the documentation on `reflect-client-php`](https://github.com/VictorWesterlund/reflect-client-php?tab=readme-ov-file#making-api-calls) for more info until I write a full documentation for this framework.. sigh.