### PR TITLE
Add `get_user_id` and `get_user_groups` methods to `Reflect\Request`

### DIFF
--- a/src/api/builtin/Request.php
+++ b/src/api/builtin/Request.php
@@ -9,6 +9,14 @@
 
 	class Request extends Database {
 		public static function get_api_key(): ?string {
-			return parent::get_key_from_request();
+			return parent::$api_key;
+		}
+
+		public static function get_user(): ?string {
+			return parent::$user_id;
+		}
+
+		public static function get_user_groups(): array {
+			return parent::$user_groups;
 		}
 	}


### PR DESCRIPTION
This PR adds two new "Reflection" methods to `Reflect\Request` which can be used to retrieve the callers user ID and groups respectively.